### PR TITLE
Disable hit testing

### DIFF
--- a/Sources/Shiny/ShinyView.swift
+++ b/Sources/Shiny/ShinyView.swift
@@ -76,6 +76,7 @@ internal struct ShinyView<Content>: View where Content: View {
                         .animation(.default)
                 }
                 .mask(self.content)
+                .allowsHitTesting(false)
             })
     }
 }


### PR DESCRIPTION
Disables hit testing on the gradient, which could interfere with system gestures for context menus, making space that appeared empty actually trigger the action, and prevent gestures from being recognized in other controls.